### PR TITLE
tests - access to local orchestrator-router

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 install:
   - echo $TRAVIS_COMMIT
   - echo $TRAVIS_COMMIT > REVISION
-  - docker network create syrup-router_api-tests
+  - docker network create orchestrator-router_api-tests
   - docker-compose build tests
 
 script:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ ERROR_NOTIFICATION_EMAIL={your_email}
 Build image and run tests
 
 ```bash
-docker network create syrup-router_api-tests
+docker network create orchestrator-router_api-tests
 docker-compose build tests
 docker-compose run --rm tests ./vendor/bin/phpunit
 ``` 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,4 +18,4 @@ services:
 networks:
   default:
     external:
-      name: syrup-router_api-tests
+      name: orchestrator-router_api-tests


### PR DESCRIPTION
Related to: https://github.com/keboola/orchestrator-router/pull/1

Možnost spouštět proti lokálně nahozenému https://github.com/keboola/orchestrator-router
Nahrazuje zdockerovaný lokální syrup-router